### PR TITLE
Fixed windows build

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -35,6 +35,7 @@
         "electron-log": "^4.3.5",
         "electron-store": "6.0.1",
         "electron-updater": "4.3.5",
+        "ffi-napi": "^4.0.3",
         "graphql": "^15.5.0",
         "hazardous": "^0.3.0",
         "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
- add 'ffi-napi' to dependencies
- am able to build a windows installer