### PR TITLE
Release v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 # Application installers
 
-| Operating System             | Download                                                                                                                                                                                                                             |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Windows (32 and 64-bit .exe) | <a href='https://github.com/GitStartHQ/DevTime/releases/download/v0.3.0/GitStart-DevTime-Setup-0.3.0.exe'><img alt='Get it on Windows' width="134px" src='https://github.com/MayGo/tockler/raw/master/badges/BadgeWindows.png'/></a> |
-| macOS (.dmg)                 | <a href='https://github.com/GitStartHQ/DevTime/releases/download/v0.3.0/GitStart-DevTime-0.3.0.dmg'><img alt='Get it on macOS' width="134px" src='https://github.com/MayGo/tockler/raw/master/badges/BadgeMacOS.png'/></a>           |
-| Linux (.deb)                 | <a href='https://github.com/GitStartHQ/DevTime/releases/download/v0.3.0/devtime_0.3.0_amd64.deb'><img alt='Get it on Linux' width="134px" src='https://github.com/MayGo/tockler/raw/master/badges/BadgeLinux.png'/></a>              |
+| Operating System                 | Download                                                                                                                                                                                                                  |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Windows (32-bit and 64-bit .exe) | <a href='https://github.com/GitStartHQ/DevTime/releases/latest/download/GitStart-DevTime.exe'><img alt='Get it on Windows' width="134px" src='https://github.com/MayGo/tockler/raw/master/badges/BadgeWindows.png'/></a>  |
+| macOS (.dmg)                     | <a href='https://github.com/GitStartHQ/DevTime/releases/latest/download/GitStart-DevTime.dmg'><img alt='Get it on macOS' width="134px" src='https://github.com/MayGo/tockler/raw/master/badges/BadgeMacOS.png'/></a>      |
+| Linux (.deb)                     | <a href='https://github.com/GitStartHQ/DevTime/releases/latest/download/GitStart-DevTime.deb'><img alt='Get it on Linux' width="134px" src='https://github.com/MayGo/tockler/raw/master/badges/BadgeLinux.png'/></a>      |
+| Linux (.AppImage)                | <a href='https://github.com/GitStartHQ/DevTime/releases/latest/download/GitStart-DevTime.AppImage'><img alt='Get it on Linux' width="134px" src='https://github.com/MayGo/tockler/raw/master/badges/BadgeLinux.png'/></a> |
 
 # Made with
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "devtime",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "private": true,
     "dependencies": {
         "@react-hook/window-size": "^1.0.12",

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -29,6 +29,13 @@ protocols:
       schemes:
           - x-gitstart-devtime
 
+win:
+    target:
+        - target: 'nsis'
+          arch:
+              - x64
+              - ia32
+
 mac:
     category: public.app-category.productivity
 

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -6,6 +6,7 @@ asarUnpack:
     - shared
 extraResources:
     - tracker.db
+artifactName: '${productName}.${ext}'
 
 directories:
     output: 'packaged'

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "devtime",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Automatically track applications usage and working time",
     "author": "GitStart <contact@gitstart.com>",
     "license": "GPL-2.0",
@@ -21,7 +21,7 @@
         "build": "webpack --progress --env.production --mode=production",
         "build_mac": "yarn build && electron-builder -c electron-builder.yml --mac",
         "build_linux": "yarn build && electron-builder -c electron-builder.yml --linux",
-        "build_windows": "yarn build && electron-builder -c electron-builder.yml --win",
+        "build_windows": "yarn build && electron-builder -c electron-builder.yml --win --ia32 --x64",
         "release": "yarn build && electron-builder -c electron-builder.yml --mac --linux --win --ia32 --x64",
         "full_release": "yarn prepare_client && yarn release"
     },
@@ -38,7 +38,7 @@
         "electron-updater": "4.3.5",
         "ffi-napi": "^4.0.3",
         "graphql": "^15.5.0",
-        "hazardous": "^0.3.0",
+        "hazardous": "^0.3.1",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.3",
         "knex": "^0.21.13",

--- a/electron/package.json
+++ b/electron/package.json
@@ -38,7 +38,7 @@
         "electron-updater": "4.3.5",
         "ffi-napi": "^4.0.3",
         "graphql": "^15.5.0",
-        "hazardous": "^0.3.1",
+        "hazardous": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.3",
         "knex": "^0.21.13",

--- a/electron/package.json
+++ b/electron/package.json
@@ -21,8 +21,8 @@
         "build": "webpack --progress --env.production --mode=production",
         "build_mac": "yarn build && electron-builder -c electron-builder.yml --mac",
         "build_linux": "yarn build && electron-builder -c electron-builder.yml --linux",
-        "build_windows": "yarn build && electron-builder -c electron-builder.yml --win --ia32 --x64",
-        "release": "yarn build && electron-builder -c electron-builder.yml --mac --linux --win --ia32 --x64",
+        "build_windows": "yarn build && electron-builder -c electron-builder.yml --win",
+        "release": "yarn build && electron-builder -c electron-builder.yml --mac --linux --win",
         "full_release": "yarn prepare_client && yarn release"
     },
     "dependencies": {


### PR DESCRIPTION
- Fix Windows build
---
- Add `ia32` and `x64` as nsis target `arch`s
- Change artifact name to not include version 