### PR TITLE
Ignore NATIVE apps + NO_TITLE -> null

### DIFF
--- a/electron/app/background-service.ts
+++ b/electron/app/background-service.ts
@@ -37,14 +37,14 @@ export class BackgroundService {
         return await Promise.all(promiseArray);
     }
 
-    async createOrUpdate(rawItem) {
+    async createOrUpdate(rawItem: Partial<TrackItem>) {
         try {
             let color = await appSettingService.getAppColor(rawItem.app);
             rawItem.color = color;
 
             let item: TrackItem;
 
-            let type: TrackItemType = rawItem.taskName;
+            let type = rawItem.taskName;
 
             if (!type) {
                 throw new Error('TaskName not defined.');
@@ -54,8 +54,9 @@ export class BackgroundService {
                 let items = BackgroundUtils.splitItemIntoDayChunks(rawItem);
 
                 if (stateManager.hasSameRunningTrackItem(rawItem)) {
-                    let firstItem = items.shift();
-                    await stateManager.endRunningTrackItem(firstItem);
+                    const currentItem = stateManager.getCurrentTrackItem(type);
+                    await stateManager.endRunningTrackItem(currentItem);
+                    items.shift();
                 }
                 try {
                     let savedItems = await this.createItems(items);
@@ -75,7 +76,7 @@ export class BackgroundService {
             } else {
                 if (stateManager.hasSameRunningTrackItem(rawItem)) {
                     item = await stateManager.updateRunningTrackItemEndDate(type);
-                } else if (!stateManager.hasSameRunningTrackItem(rawItem)) {
+                } else {
                     item = await stateManager.createNewRunningTrackItem(rawItem);
                 }
             }

--- a/electron/app/jobs/app-track-item-job.ts
+++ b/electron/app/jobs/app-track-item-job.ts
@@ -99,7 +99,7 @@ export class AppTrackItemJob {
         rawItem.endDate = new Date();
 
         // logger.debug('rawitem has no app', result);
-        if (result.owner && result.owner.name) {
+        if (result.owner && result.owner.name && !['explorer.exe'].includes(result.owner.name)) {
             rawItem.app = result.owner.name;
         } else {
             rawItem.app = 'NATIVE';
@@ -107,7 +107,7 @@ export class AppTrackItemJob {
 
         if (!result.title) {
             // logger.error('rawitem has no title', result);
-            rawItem.title = 'NO_TITLE';
+            rawItem.title = null;
         } else {
             rawItem.title = result.title.replace(/\n$/, '').replace(/^\s/, '');
         }

--- a/electron/app/jobs/status-track-item-job.ts
+++ b/electron/app/jobs/status-track-item-job.ts
@@ -8,6 +8,7 @@ import { appConstants } from '../app-constants';
 import { sendToTrayWindow } from '../window-manager';
 import { TrackItem } from '../models/TrackItem';
 import { logService } from '../services/log-service';
+import { TrackItemType } from '../enums/track-item-type';
 
 let logger = logManager.getLogger('StatusTrackItemJob');
 
@@ -58,7 +59,7 @@ export class StatusTrackItemJob {
         }
 
         let rawItem: Partial<TrackItem> = {
-            taskName: 'StatusTrackItem',
+            taskName: TrackItemType.StatusTrackItem,
             app: state,
             title: state.toString().toLowerCase(),
             beginDate: BackgroundUtils.currentTimeMinusJobInterval(),

--- a/electron/app/models/TrackItem.ts
+++ b/electron/app/models/TrackItem.ts
@@ -1,4 +1,5 @@
 import { Model } from 'objection';
+import { TrackItemType } from '../enums/track-item-type';
 
 export class TrackItem extends Model {
     static tableName = 'TrackItems';
@@ -6,7 +7,7 @@ export class TrackItem extends Model {
     // from Tockler
     id!: number;
     app!: string;
-    taskName!: string;
+    taskName!: TrackItemType;
     title!: string;
     url!: string;
     color!: string;

--- a/electron/app/services/track-item-service.ts
+++ b/electron/app/services/track-item-service.ts
@@ -11,7 +11,7 @@ import moment = require('moment');
 export class TrackItemService {
     logger = logManager.getLogger('TrackItemService');
 
-    async createTrackItem(trackItemAttributes: TrackItem): Promise<TrackItem> {
+    async createTrackItem(trackItemAttributes: Partial<TrackItem>): Promise<TrackItem> {
         let trackItem = await TrackItem.query().insert(trackItemAttributes);
         // this.logger.debug(`Created trackItem :`, trackItem.toJSON());
         return trackItem;

--- a/electron/app/state-manager.ts
+++ b/electron/app/state-manager.ts
@@ -108,8 +108,15 @@ export class StateManager {
         return this.getCurrentTrackItem(TrackItemType.StatusTrackItem);
     }
 
-    hasSameRunningTrackItem(rawItem): boolean {
-        return BackgroundUtils.isSameItems(rawItem, this.getCurrentTrackItem(rawItem.taskName));
+    hasSameRunningTrackItem(rawItem: Partial<TrackItem>): boolean {
+        // We want to ignore (i.e. prolongue the last running item) native processes like Mission Control on macOS or Tab explorer on Windows
+        if (!rawItem.app || rawItem.app === 'NATIVE') {
+            return true;
+        }
+        return BackgroundUtils.isSameItems(
+            rawItem,
+            this.getCurrentTrackItem(rawItem.taskName as TrackItemType),
+        );
     }
 
     resetCurrentTrackItem(type: TrackItemType) {
@@ -162,7 +169,7 @@ export class StateManager {
 
     async createOnlineTrackItem() {
         let rawItem: Partial<TrackItem> = {
-            taskName: 'StatusTrackItem',
+            taskName: TrackItemType.StatusTrackItem,
             app: State.Online,
             title: State.Online.toString().toLowerCase(),
             beginDate: new Date(),
@@ -184,7 +191,7 @@ export class StateManager {
         return runningItem;
     }
 
-    async createNewRunningTrackItem(rawItem: TrackItem) {
+    async createNewRunningTrackItem(rawItem: Partial<TrackItem>) {
         await this.endRunningTrackItem(rawItem);
 
         const now = new Date();


### PR DESCRIPTION
This PR does:
- Ignores TrackItems where item.app is null or is 'NATIVE' (happens when using Mission Control or Launchpad on macOS, or Tab explorer on Windows.
- If the window has no title, then default to null instead of 'NO_TITLE'