### PR TITLE
Fix v0.5.0 errors

### DIFF
--- a/client/src/components/Settings/LogList.tsx
+++ b/client/src/components/Settings/LogList.tsx
@@ -47,7 +47,7 @@ export const LogList = () => {
     return (
         <>
             {logs.length > 0 ? (
-                <Typography.Text type="secondary">
+                <Typography.Text type="secondary" style={{ marginBottom: '8px' }}>
                     You can ignore errors/warnings that are 10 minutes or older as they don't seem
                     to be repeating. Repeating errors/warnings will update the time (i.e. "... ago")
                     to be less than 10 minutes.

--- a/client/src/components/Settings/LogList.tsx
+++ b/client/src/components/Settings/LogList.tsx
@@ -18,7 +18,7 @@ export const LogList = () => {
     const getAllLogs = async () => {
         const newLogs = await findAllLogs(
             moment()
-                .subtract(1, 'day')
+                .subtract(3, 'hours')
                 .toDate(),
         );
         setLogs(newLogs);
@@ -49,7 +49,8 @@ export const LogList = () => {
             {logs.length > 0 ? (
                 <Typography.Text type="secondary">
                     You can ignore errors/warnings that are 10 minutes or older as they don't seem
-                    to be repeating.
+                    to be repeating. Repeating errors/warnings will update the time (i.e. "... ago")
+                    to be less than 10 minutes.
                 </Typography.Text>
             ) : null}
             {logs.map(log => (

--- a/client/src/components/Settings/LogList.tsx
+++ b/client/src/components/Settings/LogList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Alert } from 'antd';
+import { Alert, Typography } from 'antd';
 import { findAllLogs } from '../../services/logs-api';
 import moment from 'moment';
 
@@ -46,6 +46,12 @@ export const LogList = () => {
 
     return (
         <>
+            {logs.length > 0 ? (
+                <Typography.Text type="secondary">
+                    You can ignore errors/warnings that are 10 minutes or older as they don't seem
+                    to be repeating.
+                </Typography.Text>
+            ) : null}
             {logs.map(log => (
                 <Alert
                     type={

--- a/electron/app/services/log-service.ts
+++ b/electron/app/services/log-service.ts
@@ -7,6 +7,14 @@ export class LogService {
 
     async createOrUpdateLog(logAttributes: Partial<Log>): Promise<Log> {
         let log: Log = null;
+        // Skip known/unfixable errors
+        if (logAttributes.message.includes("'endDate' of null")) {
+            return log;
+        }
+        if (logAttributes.message.includes('getaddrinfo ENOTFOUND hasura.gitstart.com')) {
+            logAttributes.message =
+                'GitStart DevTime was disconnected. Please make sure you are connected to the internet.';
+        }
         if (
             this.lastLog &&
             logAttributes.type === this.lastLog.type &&


### PR DESCRIPTION
- Fix errors with violation of exclusion constraint `UQ_USER_WORK_LOG_NON_OVERLAPPING`
- Automatically dismiss errors that contain `'endDate' of null`
- Reword errors that contain `getaddrinfo ENOTFOUND hasura.gitstart.com` into saying that there was a problem connecting and the user should make sure they are connected.
- Add message saying they can ignore errors older than 10 minutes.
- Only show logs from the past 3 hours.