### PR TITLE
Release v0.5.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "devtime",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "private": true,
     "dependencies": {
         "@react-hook/window-size": "^1.0.12",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "devtime",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Automatically track applications usage and working time",
     "author": "GitStart <contact@gitstart.com>",
     "license": "GPL-2.0",


### PR DESCRIPTION
Patching the following:
- Fix errors with violation of exclusion constraint `UQ_USER_WORK_LOG_NON_OVERLAPPING`
- Automatically dismiss errors that contain `'endDate' of null`
- Reword errors that contain `getaddrinfo ENOTFOUND hasura.gitstart.com` into saying that there was a problem connecting and the user should make sure they are connected.
- Add message saying they can ignore errors older than 10 minutes.
- Only show logs from the past 3 hours.